### PR TITLE
Bump package versions and update docs for v3.0.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,4 @@
+# Copilot Instructions
+
+## Project Guidelines
+- In this repo's template versioning discussion, generated scaffold output (like package versions in MyGenerator.csproj/MyGenerator.Tests.csproj) is considered a user-visible contract when deciding package version bumps.

--- a/templates/SourceGeneratorTemplate/SourceGenerator.Template.csproj
+++ b/templates/SourceGeneratorTemplate/SourceGenerator.Template.csproj
@@ -4,7 +4,7 @@
     <!-- NuGet Package Settings -->
     <PackageType>Template</PackageType>
     <PackageId>CNinnovation.Templates.SourceGenerator</PackageId>
-    <PackageVersion>1.2.0</PackageVersion>
+    <PackageVersion>2.0.0</PackageVersion>
     <Title>.NET Source Generator Template</Title>
     <Description>A template for creating .NET source generators with tests and snapshot testing</Description>
     <PackageTags>dotnet-new;templates;sourcegenerator;roslyn;csharp</PackageTags>

--- a/templates/SourceGeneratorTemplate/content/MyGenerator.Tests/MyGenerator.Tests.csproj
+++ b/templates/SourceGeneratorTemplate/content/MyGenerator.Tests/MyGenerator.Tests.csproj
@@ -11,17 +11,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/SourceGeneratorTemplate/content/MyGenerator/MyGenerator.csproj
+++ b/templates/SourceGeneratorTemplate/content/MyGenerator/MyGenerator.csproj
@@ -17,8 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/SourceGeneratorTemplate/content/README.md
+++ b/templates/SourceGeneratorTemplate/content/README.md
@@ -201,14 +201,14 @@ same as in xUnit v2.
 This template uses the following NuGet packages:
 
 ### Source Generator
-- **Microsoft.CodeAnalysis.CSharp** (5.0.0) – Roslyn C# compiler API
-- **Microsoft.CodeAnalysis.Analyzers** (4.14.0) – Analyzer development tools
+- **Microsoft.CodeAnalysis.CSharp** (5.3.0) – Roslyn C# compiler API
+- **Microsoft.CodeAnalysis.Analyzers** (5.3.0) – Analyzer development tools
 
 ### Test Projects
 - **xUnit v3** (3.2.2) – Unit testing framework
-- **Microsoft.NET.Test.Sdk** (18.3.0) – Test platform
+- **Microsoft.NET.Test.Sdk** (18.7.0) – Test platform
 - **xunit.runner.visualstudio** (3.1.5) – Visual Studio test runner
-- **coverlet.collector** (8.0.0) – Code coverage collector
+- **coverlet.collector** (10.0.1) – Code coverage collector
 
 ### Snapshot Testing
 - **Verify.XunitV3** (31.13.2) – Snapshot testing library

--- a/templates/SourceGeneratorTemplate/content/THIRD-PARTY-NOTICES.md
+++ b/templates/SourceGeneratorTemplate/content/THIRD-PARTY-NOTICES.md
@@ -7,14 +7,14 @@ This project uses the following third-party packages and dependencies:
 ## Source Generator Project
 
 ### Microsoft.CodeAnalysis.Analyzers
-- **Version:** 4.14.0
+- **Version:** 5.3.0
 - **License:** MIT
 - **Copyright:** .NET Foundation and Contributors
 - **Repository:** https://github.com/dotnet/roslyn
 - **Purpose:** Provides analyzers for developing Roslyn analyzers and source generators
 
 ### Microsoft.CodeAnalysis.CSharp
-- **Version:** 5.0.0
+- **Version:** 5.3.0
 - **License:** MIT
 - **Copyright:** .NET Foundation and Contributors
 - **Repository:** https://github.com/dotnet/roslyn
@@ -25,7 +25,7 @@ This project uses the following third-party packages and dependencies:
 ## Test Projects
 
 ### Microsoft.NET.Test.Sdk
-- **Version:** 18.3.0
+- **Version:** 18.7.0
 - **License:** MIT
 - **Copyright:** Microsoft Corporation
 - **Repository:** https://github.com/microsoft/vstest
@@ -46,7 +46,7 @@ This project uses the following third-party packages and dependencies:
 - **Purpose:** Visual Studio test runner for xUnit
 
 ### coverlet.collector
-- **Version:** 8.0.0
+- **Version:** 10.0.1
 - **License:** MIT
 - **Copyright:** tonerdo and Contributors
 - **Repository:** https://github.com/coverlet-coverage/coverlet


### PR DESCRIPTION
Bump package versions and update docs for v2.0.0

Updated Microsoft.CodeAnalysis.CSharp, Analyzers, Test.Sdk, and coverlet.collector to latest versions. Raised SourceGenerator.Template to v2.0.0. Refreshed README and THIRD-PARTY-NOTICES with new versions. Added note to copilot-instructions.md about scaffold output as a versioning contract.